### PR TITLE
fix: Avoid re-building whole image when change py code

### DIFF
--- a/.docker/.dockerignore
+++ b/.docker/.dockerignore
@@ -1,1 +1,4 @@
 bonus_superlinked_rag/server
+.git/
+__pycache__/
+.venv/


### PR DESCRIPTION
### Issue

Changing just one line of Python code will force you re compile iusing `docker compose up --build`

For example, changing `data-crawler` python code and starting up the service

```
docker compose -f docker-compose.yml up data-crawlers  --build -d
```

provokes re-building the whole image, which is a lot of time.

### Fix

Add .git and other formats into the `.dockerignore` file